### PR TITLE
issue#24 Фикс бага, когда пользователю добавляются дубликаты блюд

### DIFF
--- a/db/migrate/20170328131232_add_unique_index_to_user_menu_dishes.rb
+++ b/db/migrate/20170328131232_add_unique_index_to_user_menu_dishes.rb
@@ -1,3 +1,5 @@
+class UserMenuDish < ActiveRecord::Base; end
+
 class AddUniqueIndexToUserMenuDishes < ActiveRecord::Migration[5.0]
   def change
     grouped = UserMenuDish.all.group_by{ |model| [model.user_menu_id, model.dish_id] }
@@ -6,6 +8,6 @@ class AddUniqueIndexToUserMenuDishes < ActiveRecord::Migration[5.0]
       duplicates.each{ |duplicate| duplicate.destroy }
     end
 
-    add_index :user_menu_dishes, [:user_menu_id, :dish_id], :unique => true
+    add_index :user_menu_dishes, [:user_menu_id, :dish_id], unique: true
   end
 end

--- a/db/migrate/20170328131232_add_unique_index_to_user_menu_dishes.rb
+++ b/db/migrate/20170328131232_add_unique_index_to_user_menu_dishes.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToUserMenuDishes < ActiveRecord::Migration[5.0]
+  def change
+    grouped = UserMenuDish.all.group_by{ |model| [model.user_menu_id, model.dish_id] }
+    grouped.values.each do |duplicates|
+      duplicates.shift
+      duplicates.each{ |duplicate| duplicate.destroy }
+    end
+
+    add_index :user_menu_dishes, [:user_menu_id, :dish_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170211145604) do
+ActiveRecord::Schema.define(version: 20170328131232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20170211145604) do
     t.integer "user_menu_id"
     t.integer "dish_id"
     t.index ["dish_id"], name: "index_user_menu_dishes_on_dish_id", using: :btree
+    t.index ["user_menu_id", "dish_id"], name: "index_user_menu_dishes_on_user_menu_id_and_dish_id", unique: true, using: :btree
     t.index ["user_menu_id"], name: "index_user_menu_dishes_on_user_menu_id", using: :btree
   end
 

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -6,7 +6,7 @@ const url = urljoin(baseUrl, 'users');
 const apiWrapper = apiClientFactory(url);
 
 apiWrapper.getMenus = id => request(urljoin(url, id, 'menus'), 'GET');
-apiWrapper.setMenu = (userId, id, dishes, description, neem) => {
+apiWrapper.setMenu = (userId, id, { dishes, description, neem }) => {
   const menuUrl = urljoin(baseUrl, 'user_menus', id);
   const payload = {
     user_menu: { dishes, description, neem },

--- a/frontend/src/components/Menu/DailyMenu.vue
+++ b/frontend/src/components/Menu/DailyMenu.vue
@@ -7,7 +7,11 @@
     </h1>
 
     <div v-if="errors.length > 0" class="daily-menu__errors">
-      <span>{{errors.join(', ')}}</span>
+      <ul>
+        <li v-for="error in errors">
+          {{error}}
+        </li>
+      </ul>
     </div>
 
     <div class="daily-menu__list">
@@ -38,7 +42,7 @@
   import Switcher from '../Switcher';
 
   const userId = localStorage.getItem('user_uid');
-  const MENU_SAVE_ERROR = 'При сохранении меню возникла ошибка. Попробуйте обновить страницу';
+  const MENU_SAVE_ERROR = 'При сохранении меню возникла ошибка. Попробуйте обновить страницу.';
 
   let lastState;
 

--- a/frontend/src/components/Menu/DailyMenu.vue
+++ b/frontend/src/components/Menu/DailyMenu.vue
@@ -6,6 +6,10 @@
       <a v-on:click="setToDefault" class="default_link">Сбросить</a>
     </h1>
 
+    <div v-if="errors.length > 0" class="daily-menu__errors">
+      <span>{{errors.join(', ')}}</span>
+    </div>
+
     <div class="daily-menu__list">
       <menu-dish
         :date="date"
@@ -33,9 +37,10 @@
   import MenuPresenter from '../../presenters/MenuPresenter';
   import Switcher from '../Switcher';
 
-  let lastState;
-
   const userId = localStorage.getItem('user_uid');
+  const MENU_SAVE_ERROR = 'При сохранении меню возникла ошибка. Попробуйте обновить страницу';
+
+  let lastState;
 
   function getSelectedDishes(dishTypes) {
     return _.reduce(dishTypes, (acc, dishes) => {
@@ -84,6 +89,7 @@
         date: MenuPresenter.date(this.day.date),
         dishTypes: types,
         isSwitchOn: !this.day.neem,
+        errors: [],
       };
     },
     methods: {
@@ -94,15 +100,13 @@
           neem: this.day.neem,
         };
 
-        if (areSameStates(lastState, currentState)) {
-          return;
-        }
+        if (areSameStates(lastState, currentState)) return;
 
         lastState = currentState;
         usersService
           .setMenu(userId, this.day.id, currentState)
-          .catch((err) => {
-            alert(err);
+          .catch(() => {
+            this.errors.push(MENU_SAVE_ERROR);
           });
       },
 
@@ -227,6 +231,15 @@
     color: #333;
     transition: color 300ms ease-in-out;
   }
+}
+
+.daily-menu__errors {
+  padding: 20px;
+  background-color: #f44336;
+  color: white;
+  margin-bottom: 15px;
+  border-radius: 5px;
+  opacity: 0.7;
 }
 
 .daily-menu__actions {

--- a/frontend/src/components/Menu/DailyMenu.vue
+++ b/frontend/src/components/Menu/DailyMenu.vue
@@ -33,6 +33,7 @@
   import MenuPresenter from '../../presenters/MenuPresenter';
   import Switcher from '../Switcher';
 
+  let lastState;
 
   const userId = localStorage.getItem('user_uid');
 
@@ -52,6 +53,10 @@
       ...dish,
       selected: false,
     }));
+  }
+
+  function areSameStates(oldState, newState) {
+    return _.isEqual(oldState, newState);
   }
 
   export default {
@@ -83,9 +88,22 @@
     },
     methods: {
       sendData() {
+        const currentState = {
+          dishes: getSelectedDishes(this.dishTypes),
+          description: this.day.description,
+          neem: this.day.neem,
+        };
+
+        if (areSameStates(lastState, currentState)) {
+          return;
+        }
+
+        lastState = currentState;
         usersService
-          .setMenu(userId, this.day.id, getSelectedDishes(this.dishTypes), this.day.description,
-            this.day.neem);
+          .setMenu(userId, this.day.id, currentState)
+          .catch((err) => {
+            alert(err);
+          });
       },
 
       setToDefault() {

--- a/frontend/src/components/Menu/DailyMenu.vue
+++ b/frontend/src/components/Menu/DailyMenu.vue
@@ -46,7 +46,6 @@
   const MENU_SAVE_ERROR = 'При сохранении меню возникла ошибка. Попробуйте обновить страницу.';
 
   let lastState;
-  let commentSendTimeout;
 
   function getSelectedDishes(dishTypes) {
     return _.reduce(dishTypes, (acc, dishes) => {
@@ -64,10 +63,6 @@
       ...dish,
       selected: false,
     }));
-  }
-
-  function areSameStates(oldState, newState) {
-    return _.isEqual(oldState, newState);
   }
 
   export default {
@@ -98,6 +93,9 @@
         errors: [],
       };
     },
+    created() {
+      this.sendComment = _.debounce(this.sendData, COMMENT_SEND_TIMEOUT);
+    },
     methods: {
       sendData() {
         const currentState = {
@@ -106,7 +104,7 @@
           neem: this.day.neem,
         };
 
-        if (areSameStates(lastState, currentState)) return;
+        if (_.isEqual(lastState, currentState)) return;
 
         lastState = currentState;
         usersService
@@ -187,11 +185,7 @@
 
       onChangeComment(event) {
         this.day.description = event.target.value;
-        if (commentSendTimeout) {
-          clearTimeout(commentSendTimeout);
-          commentSendTimeout = null;
-        }
-        commentSendTimeout = setTimeout(this.sendData, COMMENT_SEND_TIMEOUT);
+        this.sendComment();
       },
 
       menuSwitchToggle(value) {

--- a/frontend/src/components/Menu/DailyMenu.vue
+++ b/frontend/src/components/Menu/DailyMenu.vue
@@ -42,9 +42,11 @@
   import Switcher from '../Switcher';
 
   const userId = localStorage.getItem('user_uid');
+  const COMMENT_SEND_TIMEOUT = 350;
   const MENU_SAVE_ERROR = 'При сохранении меню возникла ошибка. Попробуйте обновить страницу.';
 
   let lastState;
+  let commentSendTimeout;
 
   function getSelectedDishes(dishTypes) {
     return _.reduce(dishTypes, (acc, dishes) => {
@@ -185,7 +187,11 @@
 
       onChangeComment(event) {
         this.day.description = event.target.value;
-        this.sendData();
+        if (commentSendTimeout) {
+          clearTimeout(commentSendTimeout);
+          commentSendTimeout = null;
+        }
+        commentSendTimeout = setTimeout(this.sendData, COMMENT_SEND_TIMEOUT);
       },
 
       menuSwitchToggle(value) {


### PR DESCRIPTION
Лог изменений:

- В серверной части добавлена миграция, чистящая старые дубли и создающая уникальный индекс в таблице user_menu_dishes для по столбцам user_menu_id и dish_id для того, чтобы случаи с дублирующими вставками пресекались в т.ч. на уровне БД.
- В клиентской части:
    - Добавлена сверка предыдущего отправленного состояния с новым перед отправкой. Если ничего не изменилось, ничего не отправляем.
    - Добавлен вывод сообщений в случае, если при сохранении меню возникают ошибки.
    - Добавлен таймаут отправки комментариев для того, чтобы не бомбить сервер запросами, которые могут привести к попытке записи дублирующихся данных. Отправка данных по вводу комментария происходит через 350 мс после того, как пользователь перестал вводить текст, а не на каждой введенной букве. 