### PR TITLE
Добавил воздуха между именем и кнопкой выхода.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -69,4 +69,7 @@ table {
 * {
   box-sizing: border-box;
 }
+a.logout_icon[href="/logout"] {
+	margin-left: 1em;
+}
 </style>


### PR DESCRIPTION
В правом верхнем углу нарушается правило внутреннего и внешнего:
расстояние между именем и фамилией должно быть меньше, чем расстояние
от них обоих до кнопки выхода.